### PR TITLE
Bug Fix: Fixing missing `type` issue on `spec` for EKS Observability Template.

### DIFF
--- a/backstage-templates-for-eks/eks-observability-accelerator/template-infra-monitoring.yaml
+++ b/backstage-templates-for-eks/eks-observability-accelerator/template-infra-monitoring.yaml
@@ -6,6 +6,7 @@ metadata:
   title: EKS Observability - OSS Infra Monitoring
 spec:
   owner: guest
+  type: service
   parameters:
     - properties:
         tfVars:


### PR DESCRIPTION
Fixing template issue with missing `type` for `spec` on the terraform template for EKS Observability template. 